### PR TITLE
Consolidate alert processing into application C

### DIFF
--- a/diagrams/before.drawio
+++ b/diagrams/before.drawio
@@ -1,0 +1,49 @@
+<mxfile host="app.diagrams.net" modified="2025-09-05T00:00:00.000Z" agent="AI" version="24.7.0">
+  <diagram id="before" name="Before">
+    <mxGraphModel dx="1200" dy="800" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1100" pageHeight="850" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <mxCell id="db" value="System A&#10;DB" style="shape=rectangle;whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="200" width="140" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="appA" value="Application A&#10;(MT)" style="shape=rectangle;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="260" y="120" width="180" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="appB" value="Application B&#10;(MX)" style="shape=rectangle;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="260" y="280" width="180" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="mq" value="Downstream A&#10;MQ Endpoint (MT)" style="shape=rectangle;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="540" y="120" width="220" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="http" value="Downstream A&#10;HTTP Endpoint (MX)" style="shape=rectangle;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="540" y="280" width="220" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="e1" value="pull MT alerts" style="endArrow=block;html=1;rounded=0;" edge="1" parent="1" source="db" target="appA">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="0" y="0" as="offset"/>
+          </mxGeometry>
+        </mxCell>
+
+        <mxCell id="e2" value="pull MX alerts" style="endArrow=block;html=1;rounded=0;" edge="1" parent="1" source="db" target="appB">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="e3" value="IBM MQ (MT)" style="endArrow=block;html=1;rounded=0;" edge="1" parent="1" source="appA" target="mq">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="e4" value="HTTP (MX)" style="endArrow=block;html=1;rounded=0;" edge="1" parent="1" source="appB" target="http">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>
+

--- a/diagrams/tobe.drawio
+++ b/diagrams/tobe.drawio
@@ -1,0 +1,39 @@
+<mxfile host="app.diagrams.net" modified="2025-09-05T00:00:00.000Z" agent="AI" version="24.7.0">
+  <diagram id="tobe" name="To-Be">
+    <mxGraphModel dx="1200" dy="800" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1100" pageHeight="850" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <mxCell id="db" value="System A&#10;DB" style="shape=rectangle;whiteSpace=wrap;html=1;rounded=0;" vertex="1" parent="1">
+          <mxGeometry x="40" y="200" width="140" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="appC" value="Application C&#10;(ingest MT + MX)" style="shape=rectangle;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="260" y="200" width="200" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="mq" value="Downstream A&#10;MQ Endpoint (MT)" style="shape=rectangle;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="540" y="140" width="220" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="http" value="Downstream A&#10;HTTP Endpoint (MX)" style="shape=rectangle;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="540" y="260" width="220" height="60" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="e1" value="pull MT &amp; MX alerts" style="endArrow=block;html=1;rounded=0;" edge="1" parent="1" source="db" target="appC">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="e2" value="IBM MQ (MT)" style="endArrow=block;html=1;rounded=0;" edge="1" parent="1" source="appC" target="mq">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="e3" value="HTTP (MX)" style="endArrow=block;html=1;rounded=0;" edge="1" parent="1" source="appC" target="http">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>
+


### PR DESCRIPTION
Add 'Before' and 'To-Be' draw.io diagrams to visualize the consolidation of alert processing into a single application.

The diagrams illustrate the architectural shift from two separate applications (A and B) handling MT and MX alerts independently, to a single new application (C) that pulls both types of alerts and dispatches them to the appropriate downstream channels (IBM MQ for MT, HTTP for MX). This provides a clear visual comparison of the system architecture before and after the introduction of Application C.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a3c2bda-66ef-46f0-8f2b-7ffecc668aa0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a3c2bda-66ef-46f0-8f2b-7ffecc668aa0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

